### PR TITLE
Removed Deprecated "Compile" in build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -194,9 +194,9 @@ dependencies {
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     
-    compile project(':rnfgservice')
-    compile project(':rnwebrtc')
-    compile project(':rnincallmanager')
+    implementation project(':rnfgservice')
+    implementation project(':rnwebrtc')
+    implementation project(':rnincallmanager')
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'


### PR DESCRIPTION
Replaced 'compile' with 'implementation'
'compile' is now deprecated and will be removed in Gradle 7

See this https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation