### PR TITLE
Update to use openssl-legacy-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,36 +1,45 @@
 {
-  "name": "videosdk-react-native-sdk-example",
-  "version": "0.0.1",
+  "name": "react-sdk-example",
+  "version": "0.1.0",
   "private": true,
-  "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
-    "start": "react-native start",
-    "test": "jest",
-    "lint": "eslint .",
-    "android-linux": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res && react-native run-android"
-  },
+  "homepage": "https://lab.zujonow.com/react-rtc-demo/",
   "dependencies": {
-    "@react-native-firebase/app": "^15.2.0",
-    "@react-native-firebase/crashlytics": "^15.2.0",
-    "@videosdk.live/react-native-incallmanager": "^0.0.5",
-    "@videosdk.live/react-native-sdk": "^0.0.32",
-    "react": "17.0.1",
-    "react-native": "0.66.4",
-    "react-native-dotenv": "^3.1.1",
-    "react-native-video": "^5.1.1"
+    "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
+    "@videosdk.live/react-sdk": "^0.1.43",
+    "react": "^17.0.2",
+    "react-confirm-alert": "^2.7.0",
+    "react-dom": "^17.0.2",
+    "react-player": "^2.10.1",
+    "react-scripts": "4.0.3",
+    "web-vitals": "^1.0.1"
   },
-  "devDependencies": {
-    "@babel/core": "^7.14.6",
-    "@babel/runtime": "^7.14.6",
-    "@react-native-community/eslint-config": "^3.0.0",
-    "babel-jest": "^27.0.6",
-    "eslint": "^7.30.0",
-    "jest": "^27.0.6",
-    "metro-react-native-babel-preset": "^0.66.1",
-    "react-test-renderer": "17.0.1"
+  "scripts": {
+    "start": "SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
+    "kill-start": "sudo kill -9 `sudo lsof -t -i:3000` && yarn start",
+    "build": "SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
   },
-  "jest": {
-    "preset": "react-native"
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }


### PR DESCRIPTION
As current is throwing error ```library: 'digital envelope routines', reason: 'unsupported', code: 'ERR_OSSL_EVP_UNSUPPORTED' }```